### PR TITLE
fix: compile-time warning 'incompatible pointer type' in function 'posix_acl_update_mode'

### DIFF
--- a/fs/posix_acl.c
+++ b/fs/posix_acl.c
@@ -359,10 +359,11 @@ int posix_acl_update_mode(struct inode *inode, umode_t *mode_p,
 	umode_t mode = inode->i_mode;
 	int error;
 
-	error = posix_acl_update_mode(inode,
-			&inode->i_mode, &acl);
-	if (error)
+	error = posix_acl_equiv_mode(*acl, &mode);
+	if (error < 0)
 		return error;
+	if (error == 0)
+		*acl = NULL;
 	if (!in_group_p(inode->i_gid) &&
 	    !capable(CAP_FSETID))
 		mode &= ~S_ISGID;


### PR DESCRIPTION
Discard changes on previous commit (46c655e). This also fixes a recursive call in this function.